### PR TITLE
Fix Upstart eventserver service script

### DIFF
--- a/templates/default/services/upstart/eventserver.conf.erb
+++ b/templates/default/services/upstart/eventserver.conf.erb
@@ -9,7 +9,7 @@ setgid <%= @group %>
 
 limit nofile <%= @nofile %> <%= @nofile %>
 
-env PIO_EVENTSEVER_PORT=7070
+env PIO_EVENTSERVER_PORT=7070
 env JAVA_HOME=<%= @java_home %>
 
 script


### PR DESCRIPTION
Script created env variable `PIO_EVENTSEVER_PORT` (with missing R) but tried to use variable `PIO_EVENTSERVER_PORT`, causing service script not to start if default port 7070 is used.